### PR TITLE
Fix bug in issue template for question

### DIFF
--- a/.github/ISSUE_TEMPLATE/questions_help.md
+++ b/.github/ISSUE_TEMPLATE/questions_help.md
@@ -1,7 +1,7 @@
 ---
 name: Questions/Help
-about: Submit questions or requests for help regarding downgrade
-labels: 'question, needs triage'
+about: Submit questions or requests for help
+labels: 'question, triage'
 ---
 
 ## :question: Questions/Help


### PR DESCRIPTION
Replace `needs triage` label to `triage`

### Checklist

* Admin:
  - [x] No duplicate PRs
* Integration:
  - [x] Update unit tests
  - [x] Update shell completions
  - [x] Update configuration file
* Documentation:
  - [x] Update usage function
  - [x] Update mandoc
  - [x] Update readme
  - [x] Update locales
* Release:
  - [x] Update change log
  - [x] Update `DOWNGRADE_VERSION`

<!-- These are likely side tasks that would need to be completed before merging the pull request -->
<!-- If a task is not relevant to your pull request, tick it nonetheless and skip to the next task(s) -->

### Description

<!-- Describe your pull request and mention any issue(s) that it might be linked to -->

Fix label from `needs triage` to `triage`