### PR TITLE
Integrate `pacignore` into `downgrade`

### DIFF
--- a/bin/downgrade
+++ b/bin/downgrade
@@ -110,15 +110,23 @@ read_selection() {
   ((ans > 0 && ans <= $#)) && printf "%s" "${!ans}"
 }
 
+prompt_gettext() {
+  local key="$1" ans
+
+  eval_gettext "$key"
+  read -r ans
+
+  [[ "${ans,,}" == $(gettext 'y')* ]]
+}
+
 prompt_to_ignore() {
-  local pkg ans
+  local pkg
 
   for pkg; do
-    pacignore check --pacman-conf "$PACMAN_CONF" "$pkg" && return 0
-    eval_gettext "add \$pkg to IgnorePkg? [y/N] "
-    read -r ans
-    if [[ "${ans,,}" == $(gettext 'y')* ]]; then
-      pacignore add --pacman-conf "$PACMAN_CONF" "$pkg"
+    if ! pacignore check -c "$PACMAN_CONF" "$pkg"; then
+      if prompt_gettext "add \$pkg to IgnorePkg? [y/N] "; then
+        pacignore add -c "$PACMAN_CONF" "$pkg"
+      fi
     fi
   done
 }

--- a/bin/downgrade
+++ b/bin/downgrade
@@ -111,34 +111,14 @@ read_selection() {
 }
 
 prompt_to_ignore() {
-  local pkg ans ln
+  local pkg ans
 
   for pkg; do
-    grep -Eq '^IgnorePkg.*( |=)'"$pkg"'( |$)' "$PACMAN_CONF" && return 0
-
+    pacignore check --pacman-conf "$PACMAN_CONF" "$pkg" && return 0
     eval_gettext "add \$pkg to IgnorePkg? [y/N] "
     read -r ans
-
     if [[ "${ans,,}" == $(gettext 'y')* ]]; then
-      ln="$(grep -n -m 1 '^ *IgnorePkg' "$PACMAN_CONF" | cut -d : -f 1)"
-      if [ -n "$ln" ]; then
-        sed -i "$ln s/.*/& $pkg/" "$PACMAN_CONF"
-        continue
-      fi
-
-      ln="$(grep -n '^# *IgnorePkg' "$PACMAN_CONF" | tail -n 1 | cut -d : -f 1)"
-      if [ -n "$ln" ]; then
-        sed -i "$ln s/.*/&\\nIgnorePkg = $pkg/" "$PACMAN_CONF"
-        continue
-      fi
-
-      ln="$(grep -n '^ *\[options\]' "$PACMAN_CONF" | cut -d : -f 1)"
-      if [ -n "$ln" ]; then
-        sed -i "$ln s/.*/&\\nIgnorePkg = $pkg/" "$PACMAN_CONF"
-        continue
-      fi
-
-      printf "IgnorePkg = %s\\n" "$pkg" >>"$PACMAN_CONF"
+      pacignore add --pacman-conf "$PACMAN_CONF" "$pkg"
     fi
   done
 }

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -27,3 +27,5 @@ write_pacman_conf() {
 }
 
 ignore() { yes | prompt_to_ignore "$@" >/dev/null; }
+
+pacignore() { return 1; }

--- a/test/prompt_to_ignore/already-present.t
+++ b/test/prompt_to_ignore/already-present.t
@@ -1,7 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Does nothing when already present
-
-  $ write_pacman_conf "IgnorePkg = foo bar baz"
-  > ignore foo; cat "$PACMAN_CONF"
-  IgnorePkg = foo bar baz

--- a/test/prompt_to_ignore/commented-multiple.t
+++ b/test/prompt_to_ignore/commented-multiple.t
@@ -1,9 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Adds after last entry if multiple are commented
-
-  $ write_pacman_conf "#IgnorePkg = foo" "#IgnorePkg = bar"
-  > ignore bat; cat "$PACMAN_CONF"
-  #IgnorePkg = foo
-  #IgnorePkg = bar
-  IgnorePkg = bat

--- a/test/prompt_to_ignore/commented-whitespace.t
+++ b/test/prompt_to_ignore/commented-whitespace.t
@@ -1,8 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Handles whitespace accordingly
-
-  $ write_pacman_conf "#  IgnorePkg ="
-  > ignore foo; cat "$PACMAN_CONF"
-  #  IgnorePkg =
-  IgnorePkg = foo

--- a/test/prompt_to_ignore/commented.t
+++ b/test/prompt_to_ignore/commented.t
@@ -1,7 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Accepts multiple arguments
-
-  $ write_pacman_conf "IgnorePkg = foo bar"
-  > ignore baz bat quix; cat "$PACMAN_CONF"
-  IgnorePkg = foo bar baz bat quix

--- a/test/prompt_to_ignore/missing-option-present-header.t
+++ b/test/prompt_to_ignore/missing-option-present-header.t
@@ -1,9 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Adds to end of file if no entry present
-
-  $ write_pacman_conf "[options]" "OtherOption"
-  > ignore foo; cat "$PACMAN_CONF"
-  [options]
-  IgnorePkg = foo
-  OtherOption

--- a/test/prompt_to_ignore/missing-option.t
+++ b/test/prompt_to_ignore/missing-option.t
@@ -1,9 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Adds to end of file if no entry present
-
-  $ write_pacman_conf "Option" "OtherOption"
-  > ignore foo; cat "$PACMAN_CONF"
-  Option
-  OtherOption
-  IgnorePkg = foo

--- a/test/prompt_to_ignore/multiple-arguments.t
+++ b/test/prompt_to_ignore/multiple-arguments.t
@@ -1,7 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Accepts multiple arguments
-
-  $ write_pacman_conf "IgnorePkg = foo bar"
-  > ignore baz bat quix; cat "$PACMAN_CONF"
-  IgnorePkg = foo bar baz bat quix

--- a/test/prompt_to_ignore/multiple-uncommented.t
+++ b/test/prompt_to_ignore/multiple-uncommented.t
@@ -1,9 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Affects the first uncommented entry if present
-
-  $ write_pacman_conf "#IgnorePkg = foo" "#IgnorePkg = bar" "IgnorePkg = baz"
-  > ignore bat; cat "$PACMAN_CONF"
-  #IgnorePkg = foo
-  #IgnorePkg = bar
-  IgnorePkg = baz bat

--- a/test/prompt_to_ignore/no-arguments.t
+++ b/test/prompt_to_ignore/no-arguments.t
@@ -1,9 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Adds the package to existing IgnorePkg entries
-
-  $ write_pacman_conf "OptionBefore" "IgnorePkg = foo bar" "OptionAfter"
-  > ignore baz; cat "$PACMAN_CONF"
-  OptionBefore
-  IgnorePkg = foo bar baz
-  OptionAfter

--- a/test/prompt_to_ignore/user-approves.t
+++ b/test/prompt_to_ignore/user-approves.t
@@ -1,10 +1,10 @@
   $ source "$TESTDIR/../helper.sh"
 
-Does nothing when told no
+Does something when told yes
 
   $ write_pacman_conf "IgnorePkg = foo bar"
-  > echo n | prompt_to_ignore baz >/dev/null
+  > ignore baz >/dev/null
   > printf "%s\n" "exit_code=$?"
   > cat "$PACMAN_CONF"
-  exit_code=0
+  exit_code=1
   IgnorePkg = foo bar

--- a/test/prompt_to_ignore/whitespace.t
+++ b/test/prompt_to_ignore/whitespace.t
@@ -1,9 +1,0 @@
-  $ source "$TESTDIR/../helper.sh"
-
-Handles whitespace accordingly
-
-  $ write_pacman_conf "OptionBefore" "  IgnorePkg = foo bar" "OptionAfter"
-  > ignore baz; cat "$PACMAN_CONF"
-  OptionBefore
-    IgnorePkg = foo bar baz
-  OptionAfter


### PR DESCRIPTION
### Checklist

* Admin:
  - [x] No duplicate PRs
* Integration:
  - [x] Update unit tests

<!-- These are likely side tasks that would need to be completed before merging the pull request -->
<!-- If a task is not relevant to your pull request, tick it nonetheless and skip to the next task(s) -->

### Description

<!-- Describe your pull request and mention any issue(s) that it might be linked to -->

To work towards smaller and more compact PRs, I moved (and split) a commit from the `as/pacignore` branch to this branch. This PR proposes the following:

1. Use `pacignore` directly in `downgrade` as a form of integration
2. Simplify unit tests of `downgrade` to no longer test features of what is now `pacignore`. Instead, we only test integration between the two scripts.

### Pending

- [x] Use short CLI options for `pacignore` in this PR once #198 is merged