### PR TITLE
Use POSIX `getopts` in `pacignore`

### DIFF
--- a/bin/pacignore
+++ b/bin/pacignore
@@ -15,12 +15,10 @@ $(gettext "Subcommands"):
   rm     $(gettext "remove package(s) from the IgnorePkg directive")
 
 $(gettext "Options"):
-  --pacman-conf  <$(gettext "path")>
-                 $(gettext "pacman configuration file, defaults to") "/etc/pacman.conf"
-  --version      <$(gettext "flag")>
-                 $(gettext "show pacignore version")
-  -h, --help     <$(gettext "flag")>
-                 $(gettext "show help script")
+  -c  <$(gettext "path")>
+      $(gettext "pacman configuration file, defaults to") "/etc/pacman.conf"
+  -h  <$(gettext "flag")>
+      $(gettext "show help message")
 EOF
 }
 
@@ -133,19 +131,32 @@ main() {
 }
 
 parse_options() {
-  # Check for help option before doing anything else
-  for arg; do
-    if [[ "$arg" =~ ^(-h|--help)$ ]]; then
-      usage
-      return 0
-    fi
-  done
-
   # Parse the subcommand correctly
   if [[ "$1" =~ ^(ls|check|add|rm)$ ]]; then
     PACIGNORE_SUBCOMMAND="$1"
     shift
   fi
+
+  # Loop across all CLI arguments and categorize
+  while getopts hc: opt; do
+    case "$opt" in
+      h)
+        usage
+        exit 0
+        ;;
+      c)
+        PACMAN_CONF="$OPTARG"
+        ;;
+      \?)
+        usage >&2
+        return 64
+        ;;
+    esac
+    shift $((OPTIND - 1))
+  done
+
+  # parse packages from remaining afrom ments
+  pkgs=("$@")
 
   # Check if run as root for `add` or `rm` subcommands
   if ((UID)) && [[ "$PACIGNORE_SUBCOMMAND" =~ ^(add|rm)$ ]]; then
@@ -155,41 +166,6 @@ parse_options() {
     } >&2
     return 1
   fi
-
-  # Loop across all CLI arguments and categorize
-  while [[ -n "$1" ]]; do
-    case "$1" in
-      --pacman-conf)
-        if [[ -n "$2" ]]; then
-          shift
-          PACMAN_CONF="$1"
-        else
-          {
-            gettext "Missing --pacman-conf argument"
-            printf "\n"
-            usage
-          } >&2
-          return 1
-        fi
-        ;;
-      -*)
-        local current_option
-        # shellcheck disable=SC2034
-        current_option="$1"
-        {
-          eval_gettext "Unrecognized option \$current_option"
-          printf "\n"
-          usage
-        } >&2
-        return 1
-        ;;
-      *)
-        pkgs=("$@")
-        break
-        ;;
-    esac
-    shift
-  done
 
   # Check if any packages provided
   if ((!"${#pkgs[@]}")) && [ "$PACIGNORE_SUBCOMMAND" != "ls" ]; then

--- a/test/pacignore/add_failure.t
+++ b/test/pacignore/add_failure.t
@@ -3,9 +3,10 @@
 Check add failure with existing IgnorePkg entry
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > fakeroot pacignore "add" "--pacman-conf" "$PACMAN_CONF_TEST" "bar" 2>/dev/null
+  > fakeroot pacignore "add" "-c" "$PACMAN_CONF_TEST" "bar"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
+  Skipping bar as it is already ignored
   exit_code=1
   [options]
   IgnorePkg = foo bar

--- a/test/pacignore/add_success.t
+++ b/test/pacignore/add_success.t
@@ -3,7 +3,7 @@
 Check successful add in simplest configuration
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > fakeroot pacignore "add" "--pacman-conf" "$PACMAN_CONF_TEST" "baz"
+  > fakeroot pacignore "add" "-c" "$PACMAN_CONF_TEST" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -14,7 +14,7 @@ Check successful add in simplest configuration
 Check successful add in simplest configuration with whitespace
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "  IgnorePkg = foo bar")"
-  > fakeroot pacignore "add" "--pacman-conf" "$PACMAN_CONF_TEST" "baz"
+  > fakeroot pacignore "add" "-c" "$PACMAN_CONF_TEST" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -25,7 +25,7 @@ Check successful add in simplest configuration with whitespace
 Check successful add with option in between
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "# SomeOption" "IgnorePkg = foo bar")"
-  > fakeroot pacignore "add" "--pacman-conf" "$PACMAN_CONF_TEST" "baz"
+  > fakeroot pacignore "add" "-c" "$PACMAN_CONF_TEST" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -37,7 +37,7 @@ Check successful add with option in between
 Check successful add with option in between and additional IgnorePkg
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "# SomeOption" "IgnorePkg = foo" "IgnorePkg = bar")"
-  > fakeroot pacignore "add" "--pacman-conf" "$PACMAN_CONF_TEST" "baz"
+  > fakeroot pacignore "add" "-c" "$PACMAN_CONF_TEST" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -50,7 +50,7 @@ Check successful add with option in between and additional IgnorePkg
 Check successful add with options in between and additional IgnorePkg
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "# SomeOption" "IgnorePkg = foo" "# AnotherOption" "IgnorePkg = bar")"
-  > fakeroot pacignore "add" "--pacman-conf" "$PACMAN_CONF_TEST" "baz"
+  > fakeroot pacignore "add" "-c" "$PACMAN_CONF_TEST" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -64,7 +64,7 @@ Check successful add with options in between and additional IgnorePkg
 Check successful add with no prior IgnorePkg
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "# SomeOption" "# AnotherOption")"
-  > fakeroot pacignore "add" "--pacman-conf" "$PACMAN_CONF_TEST" "foo" "bar" "baz"
+  > fakeroot pacignore "add" "-c" "$PACMAN_CONF_TEST" "foo" "bar" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0

--- a/test/pacignore/check_failure.t
+++ b/test/pacignore/check_failure.t
@@ -3,7 +3,7 @@
 Test failing check
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "# SomeOption")"
-  > pacignore "check" "--pacman-conf" "$PACMAN_CONF_TEST" "baz"
+  > pacignore "check" "-c" "$PACMAN_CONF_TEST" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=1
@@ -11,7 +11,7 @@ Test failing check
   # SomeOption
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "check" "--pacman-conf" "$PACMAN_CONF_TEST" "baz"
+  > pacignore "check" "-c" "$PACMAN_CONF_TEST" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=1
@@ -19,7 +19,7 @@ Test failing check
   IgnorePkg = foo bar
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "check" "--pacman-conf" "$PACMAN_CONF_TEST" "foo" "baz"
+  > pacignore "check" "-c" "$PACMAN_CONF_TEST" "foo" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=1
@@ -27,7 +27,7 @@ Test failing check
   IgnorePkg = foo bar
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "check" "--pacman-conf" "$PACMAN_CONF_TEST" "bar" "baz"
+  > pacignore "check" "-c" "$PACMAN_CONF_TEST" "bar" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=1

--- a/test/pacignore/check_success.t
+++ b/test/pacignore/check_success.t
@@ -3,7 +3,7 @@
 Test successful check
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "check" "--pacman-conf" "$PACMAN_CONF_TEST" "foo"
+  > pacignore "check" "-c" "$PACMAN_CONF_TEST" "foo"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -11,7 +11,7 @@ Test successful check
   IgnorePkg = foo bar
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "check" "--pacman-conf" "$PACMAN_CONF_TEST" "bar"
+  > pacignore "check" "-c" "$PACMAN_CONF_TEST" "bar"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -19,7 +19,7 @@ Test successful check
   IgnorePkg = foo bar
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "check" "--pacman-conf" "$PACMAN_CONF_TEST" "foo" "bar"
+  > pacignore "check" "-c" "$PACMAN_CONF_TEST" "foo" "bar"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0

--- a/test/pacignore/ls_failure.t
+++ b/test/pacignore/ls_failure.t
@@ -3,8 +3,9 @@
 Check list failure with invalid configuration file
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "IgnorePkg = foo bar")"
-  > pacignore "ls" "--pacman-conf" "$PACMAN_CONF_TEST" 2>/dev/null
+  > pacignore "ls" "-c" "$PACMAN_CONF_TEST"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
+  Error in reading pacman configuration file
   exit_code=1
   IgnorePkg = foo bar

--- a/test/pacignore/ls_success.t
+++ b/test/pacignore/ls_success.t
@@ -3,7 +3,7 @@
 Check successful list
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "ls" "--pacman-conf" "$PACMAN_CONF_TEST"
+  > pacignore "ls" "-c" "$PACMAN_CONF_TEST"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   foo

--- a/test/pacignore/parse_failure.t
+++ b/test/pacignore/parse_failure.t
@@ -1,29 +1,71 @@
   $ source "$TESTDIR/../helper_pacignore.sh"
 
+Check that pacignore fails if unknown option provided
+
+  $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
+  > pacignore "-q" 2>&1
+  > printf "exit_code=%s\n" "$?"
+  > cat "$PACMAN_CONF_TEST"
+  *illegal option -- q (glob)
+  Usage: pacignore ls [option...]
+  Usage: pacignore {check|add|rm} [option...] <pkg> [pkg...]
+  
+  Subcommands:
+    ls     list existing packages in the IgnorePkg directive
+    check  check if a specified package is being ignored
+    add    add package(s) to the IgnorePkg directive
+    rm     remove package(s) from the IgnorePkg directive
+  
+  Options:
+    -c  <path>
+        pacman configuration file, defaults to "/etc/pacman.conf"
+    -h  <flag>
+        show help message
+  exit_code=64
+  [options]
+  IgnorePkg = foo bar
+
 Check that pacignore fails if no argument provided
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "--pacman-conf" 2>/dev/null
+  > pacignore "-c" 2>&1
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
-  exit_code=1
+  *option requires an argument -- c (glob)
+  Usage: pacignore ls [option...]
+  Usage: pacignore {check|add|rm} [option...] <pkg> [pkg...]
+  
+  Subcommands:
+    ls     list existing packages in the IgnorePkg directive
+    check  check if a specified package is being ignored
+    add    add package(s) to the IgnorePkg directive
+    rm     remove package(s) from the IgnorePkg directive
+  
+  Options:
+    -c  <path>
+        pacman configuration file, defaults to "/etc/pacman.conf"
+    -h  <flag>
+        show help message
+  exit_code=64
   [options]
   IgnorePkg = foo bar
 
 Check that pacignore fails if no root access provided for add or rm
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "add" 2>/dev/null
+  > pacignore "add" 2>&1
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
+  pacignore must be run as root for this subcommand
   exit_code=1
   [options]
   IgnorePkg = foo bar
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > pacignore "rm" 2>/dev/null
+  > pacignore "rm" 2>&1
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
+  pacignore must be run as root for this subcommand
   exit_code=1
   [options]
   IgnorePkg = foo bar
@@ -31,17 +73,47 @@ Check that pacignore fails if no root access provided for add or rm
 Check that parsing fails if no package is package is specified for add or rm
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > fakeroot pacignore "add" 2>/dev/null
+  > fakeroot pacignore "add" 2>&1
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
+  No packages provided
+  Usage: pacignore ls [option...]
+  Usage: pacignore {check|add|rm} [option...] <pkg> [pkg...]
+  
+  Subcommands:
+    ls     list existing packages in the IgnorePkg directive
+    check  check if a specified package is being ignored
+    add    add package(s) to the IgnorePkg directive
+    rm     remove package(s) from the IgnorePkg directive
+  
+  Options:
+    -c  <path>
+        pacman configuration file, defaults to "/etc/pacman.conf"
+    -h  <flag>
+        show help message
   exit_code=1
   [options]
   IgnorePkg = foo bar
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > fakeroot pacignore "rm" 2>/dev/null
+  > fakeroot pacignore "rm" 2>&1
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
+  No packages provided
+  Usage: pacignore ls [option...]
+  Usage: pacignore {check|add|rm} [option...] <pkg> [pkg...]
+  
+  Subcommands:
+    ls     list existing packages in the IgnorePkg directive
+    check  check if a specified package is being ignored
+    add    add package(s) to the IgnorePkg directive
+    rm     remove package(s) from the IgnorePkg directive
+  
+  Options:
+    -c  <path>
+        pacman configuration file, defaults to "/etc/pacman.conf"
+    -h  <flag>
+        show help message
   exit_code=1
   [options]
   IgnorePkg = foo bar

--- a/test/pacignore/parse_success.t
+++ b/test/pacignore/parse_success.t
@@ -1,0 +1,25 @@
+  $ source "$TESTDIR/../helper_pacignore.sh"
+
+Check that pacignore parses the help option correctly
+
+  $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
+  > pacignore "-h"
+  > printf "exit_code=%s\n" "$?"
+  > cat "$PACMAN_CONF_TEST"
+  Usage: pacignore ls [option...]
+  Usage: pacignore {check|add|rm} [option...] <pkg> [pkg...]
+  
+  Subcommands:
+    ls     list existing packages in the IgnorePkg directive
+    check  check if a specified package is being ignored
+    add    add package(s) to the IgnorePkg directive
+    rm     remove package(s) from the IgnorePkg directive
+  
+  Options:
+    -c  <path>
+        pacman configuration file, defaults to "/etc/pacman.conf"
+    -h  <flag>
+        show help message
+  exit_code=0
+  [options]
+  IgnorePkg = foo bar

--- a/test/pacignore/rm_failure.t
+++ b/test/pacignore/rm_failure.t
@@ -3,9 +3,10 @@
 Check rm failure with non-existant IgnorePkg entry
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > fakeroot pacignore "rm" "--pacman-conf" "$PACMAN_CONF_TEST" "baz" 2>/dev/null
+  > fakeroot pacignore "rm" "-c" "$PACMAN_CONF_TEST" "baz"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
+  Skipping baz as it is was never ignored
   exit_code=1
   [options]
   IgnorePkg = foo bar

--- a/test/pacignore/rm_success.t
+++ b/test/pacignore/rm_success.t
@@ -3,7 +3,7 @@
 Check successful rm in simplest configuration
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "IgnorePkg = foo bar")"
-  > fakeroot pacignore "rm" "--pacman-conf" "$PACMAN_CONF_TEST" "bar"
+  > fakeroot pacignore "rm" "-c" "$PACMAN_CONF_TEST" "bar"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -14,7 +14,7 @@ Check successful rm in simplest configuration
 Check successful rm in simplest configuration with whitespace
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "  IgnorePkg = foo bar")"
-  > fakeroot pacignore "rm" "--pacman-conf" "$PACMAN_CONF_TEST" "bar"
+  > fakeroot pacignore "rm" "-c" "$PACMAN_CONF_TEST" "bar"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -25,7 +25,7 @@ Check successful rm in simplest configuration with whitespace
 Check successful rm with option in between
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "# SomeOption" "IgnorePkg = foo bar")"
-  > fakeroot pacignore "rm" "--pacman-conf" "$PACMAN_CONF_TEST" "bar"
+  > fakeroot pacignore "rm" "-c" "$PACMAN_CONF_TEST" "bar"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -37,7 +37,7 @@ Check successful rm with option in between
 Check successful rm with option in between and additional IgnorePkg
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "# SomeOption" "IgnorePkg = foo" "IgnorePkg = bar")"
-  > fakeroot pacignore "rm" "--pacman-conf" "$PACMAN_CONF_TEST" "bar"
+  > fakeroot pacignore "rm" "-c" "$PACMAN_CONF_TEST" "bar"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -50,7 +50,7 @@ Check successful rm with option in between and additional IgnorePkg
 Check successful rm with options in between and additional IgnorePkg
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "# SomeOption" "IgnorePkg = foo" "# AnotherOption" "IgnorePkg = bar")"
-  > fakeroot pacignore "rm" "--pacman-conf" "$PACMAN_CONF_TEST" "bar"
+  > fakeroot pacignore "rm" "-c" "$PACMAN_CONF_TEST" "bar"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0
@@ -64,7 +64,7 @@ Check successful rm with options in between and additional IgnorePkg
 Check successful rm with options in between and additional IgnorePkg
 
   $ PACMAN_CONF_TEST="$(write_pacman_conf "[options]" "# SomeOption" "IgnorePkg = foo" "# AnotherOption" "IgnorePkg = bar")"
-  > fakeroot pacignore "rm" "--pacman-conf" "$PACMAN_CONF_TEST" "foo" "bar"
+  > fakeroot pacignore "rm" "-c" "$PACMAN_CONF_TEST" "foo" "bar"
   > printf "exit_code=%s\n" "$?"
   > cat "$PACMAN_CONF_TEST"
   exit_code=0


### PR DESCRIPTION
### Checklist

* Admin:
  - [x] No duplicate PRs
* Integration:
  - [x] Update unit tests
 
<!-- These are likely side tasks that would need to be completed before merging the pull request -->
<!-- If a task is not relevant to your pull request, tick it nonetheless and skip to the next task(s) -->

### Description

<!-- Describe your pull request and mention any issue(s) that it might be linked to -->

This PR proposes the following changes:

1. As discussed earlier, use POSIX `getopts` for pasing CLI options in lower-level scripts; specifically `pacignore` here
2. Update tests to use shorter CLI options and to test error messages as well