### PR TITLE
Patch Makefile to avoid variable-name conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [Ongoing](https://github.com/archlinux-downgrade/downgrade/compare/v11.2.0...main)
+## [Ongoing](https://github.com/archlinux-downgrade/downgrade/compare/v11.2.1...main)
 
 See [issues](https://github.com/archlinux-downgrade/downgrade/issues)
+
+## [v11.2.1](https://github.com/archlinux-downgrade/downgrade/compare/v11.2.0...v11.2.1)
+
+- [FIX] Patch internal variables in `Makefile` to avoid variable-name conflicts
 
 ## [v11.2.0](https://github.com/archlinux-downgrade/downgrade/compare/v11.1.0...v11.2.0)
 

--- a/Makefile
+++ b/Makefile
@@ -38,17 +38,17 @@ install:
 	install -Dm644 conf/downgrade.conf "$(DESTDIR)$(XDGPREFIX)/downgrade/downgrade.conf"
 	install -Dm644 doc/downgrade.8 "$(DESTDIR)$(MANPREFIX)/man8/downgrade.8"
 	install -Dm644 doc/pacignore.8 "$(DESTDIR)$(MANPREFIX)/man8/pacignore.8"
-	for script in $(SCRIPTS); do \
-	  install -Dm755 "bin/$$script" "$(DESTDIR)$(PREFIX)/bin/$$script"; \
-	  install -Dm644 "completion/$$script/bash" "$(DESTDIR)$(PREFIX)/share/bash-completion/completions/$$script"; \
-	  install -Dm644 "completion/$$script/zsh" "$(DESTDIR)$(PREFIX)/share/zsh/site-functions/_$${script}"; \
-	  install -Dm644 "completion/$$script/fish" "$(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/$${script}.fish"; \
+	for script_ in $(SCRIPTS); do \
+	  install -Dm755 "bin/$$script_" "$(DESTDIR)$(PREFIX)/bin/$$script_"; \
+	  install -Dm644 "completion/$$script_/bash" "$(DESTDIR)$(PREFIX)/share/bash-completion/completions/$$script_"; \
+	  install -Dm644 "completion/$$script_/zsh" "$(DESTDIR)$(PREFIX)/share/zsh/site-functions/_$${script_}"; \
+	  install -Dm644 "completion/$$script_/fish" "$(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/$${script_}.fish"; \
 	done
-	for po_file in locale/**/*.po; do \
-	  locale="$$(basename "$$po_file" .po)"; \
-	  script="$$(basename "$$(dirname "$$po_file")")"; \
-	  mkdir -p "$(DESTDIR)$(LOCALEPREFIX)/$$locale/LC_MESSAGES/"; \
-	  msgfmt "$$po_file" -o "$(DESTDIR)$(LOCALEPREFIX)/$$locale/LC_MESSAGES/$${script}.mo"; \
+	for po_file_ in locale/**/*.po; do \
+	  locale_="$$(basename "$$po_file_" .po)"; \
+	  script_="$$(basename "$$(dirname "$$po_file_")")"; \
+	  mkdir -p "$(DESTDIR)$(LOCALEPREFIX)/$$locale_/LC_MESSAGES/"; \
+	  msgfmt "$$po_file_" -o "$(DESTDIR)$(LOCALEPREFIX)/$$locale_/LC_MESSAGES/$${script_}.mo"; \
 	done
 
 .PHONY: uninstall
@@ -56,12 +56,12 @@ uninstall:
 	$(RM) "$(DESTDIR)$(XDGPREFIX)/downgrade/downgrade.conf" \
 	  "$(DESTDIR)$(MANPREFIX)/man8/downgrade.8" \
 	  "$(DESTDIR)$(MANPREFIX)/man8/pacignore.8"
-	for script in $(SCRIPTS); do \
-	  $(RM) "$(DESTDIR)$(PREFIX)/bin/$$script" \
-	    "$(DESTDIR)$(PREFIX)/share/bash-completion/completions/$$script" \
-	    "$(DESTDIR)$(PREFIX)/share/zsh/site-functions/_$${script}" \
-	    "$(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/$${script}.fish" \
-	    "$(DESTDIR)$(LOCALEPREFIX)"/*/"LC_MESSAGES/$${script}.mo"; \
+	for script_ in $(SCRIPTS); do \
+	  $(RM) "$(DESTDIR)$(PREFIX)/bin/$$script_" \
+	    "$(DESTDIR)$(PREFIX)/share/bash-completion/completions/$$script_" \
+	    "$(DESTDIR)$(PREFIX)/share/zsh/site-functions/_$${script_}" \
+	    "$(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/$${script_}.fish" \
+	    "$(DESTDIR)$(LOCALEPREFIX)"/*/"LC_MESSAGES/$${script_}.mo"; \
 	done
 
 VERSION ?= $(shell sed '/^DOWNGRADE_VERSION="\([^"]*\)".*$$/!d; s//\1/' bin/downgrade)

--- a/bin/downgrade
+++ b/bin/downgrade
@@ -467,7 +467,7 @@ DOWNGRADE_FROM_ALA=1
 DOWNGRADE_FROM_CACHE=1
 DOWNGRADE_MAXDEPTH=1
 DOWNGRADE_CONF="/etc/xdg/downgrade/downgrade.conf"
-DOWNGRADE_VERSION="11.2.0"
+DOWNGRADE_VERSION="11.2.1"
 
 # Main code execution
 if ((!LIB)); then


### PR DESCRIPTION
### Checklist

* Admin:
  - [x] No duplicate PRs
* Release:
  - [x] Update change log
  - [x] Update `DOWNGRADE_VERSION`

<!-- These are likely side tasks that would need to be completed before merging the pull request -->
<!-- If a task is not relevant to your pull request, simply remove its corresponding line -->

### Description

<!-- Describe your pull request and mention any issue(s) that it might be linked to -->

This PR addresses #205 by renaming internal variables in `Makefile` to reduce the chances of variable-name conflicts