### PR TITLE
Patch ZSH completions

### DIFF
--- a/completion/downgrade/zsh
+++ b/completion/downgrade/zsh
@@ -1,15 +1,15 @@
 #compdef downgrade
 
 _downgrade_caching_policy () {
-  [[ "/var/log/pacman.log" -nt "$1" ]]
+  [[ '/var/log/pacman.log' -nt "$1" ]]
 }
 
 _set_downgrade_cache_policy () {
   local update_policy
-  zstyle -s ":completion:*:*:downgrade:*" cache-policy update_policy
+  zstyle -s ':completion:*:*:downgrade:*' cache-policy update_policy
 
   if [[ -z "$update_policy" ]]; then
-    zstyle ":completion:*:*:downgrade:*" cache-policy _downgrade_caching_policy
+    zstyle ':completion:*:*:downgrade:*' cache-policy _downgrade_caching_policy
   fi
 }
 
@@ -29,7 +29,7 @@ _downgrade () {
     {-h,--help}'[show help script]' \
       '*:packages:->pkg'
 
-  if [[ $state == "pkg" ]] && [[ ! $words =~ "\s\-\-\s" ]]; then
+  if [[ "$state" == 'pkg' ]] && [[ ! "$words" =~ '\s\-\-\s' ]]; then
     local -a packages
     if ! _retrieve_cache downgrade_packages; then
       packages=($(pacman -Ssq 2>/dev/null))

--- a/completion/downgrade/zsh
+++ b/completion/downgrade/zsh
@@ -1,7 +1,7 @@
 #compdef downgrade
 
 _downgrade_caching_policy () {
-  [[ "$1" -nt /var/log/pacman.log ]]
+  [[ "/var/log/pacman.log" -nt "$1" ]]
 }
 
 _downgrade () {

--- a/completion/downgrade/zsh
+++ b/completion/downgrade/zsh
@@ -4,7 +4,17 @@ _downgrade_caching_policy () {
   [[ "/var/log/pacman.log" -nt "$1" ]]
 }
 
+_set_downgrade_cache_policy () {
+  local update_policy
+  zstyle -s ":completion:*:*:downgrade:*" cache-policy update_policy
+
+  if [[ -z "$update_policy" ]]; then
+    zstyle ":completion:*:*:downgrade:*" cache-policy _downgrade_caching_policy
+  fi
+}
+
 _downgrade () {
+  _set_downgrade_cache_policy
   _arguments -S -C \
     '--pacman[pacman command to use]:pacman command' \
     '--pacman-conf[pacman configuration file]:pacman config file:_files' \

--- a/completion/pacignore/zsh
+++ b/completion/pacignore/zsh
@@ -4,7 +4,17 @@ _pacignore_caching_policy () {
   [[ "/var/log/pacman.log" -nt "$1" ]]
 }
 
-_pacignore(){
+_set_pacignore_cache_policy () {
+  local update_policy
+  zstyle -s ":completion:*:*:pacignore:*" cache-policy update_policy
+
+  if [[ -z "$update_policy" ]]; then
+    zstyle ":completion:*:*:pacignore:*" cache-policy _pacignore_caching_policy
+  fi
+}
+
+_pacignore () {
+  _set_pacignore_cache_policy
   _arguments -S -C '1: :->subcmds' \
              '*:packages:->pkg' \
              '-c[pacman configuration file]:pacman config file:_files' \

--- a/completion/pacignore/zsh
+++ b/completion/pacignore/zsh
@@ -1,5 +1,9 @@
 #compdef pacignore
 
+_pacignore_caching_policy () {
+  [[ "$1" -nt /var/log/pacman.log ]]
+}
+
 _pacignore(){
   _arguments -S -C '1: :->subcmds' \
              '*:packages:->pkg' \
@@ -8,7 +12,10 @@ _pacignore(){
 
   if [[ $state == "pkg" ]]; then
     local -a packages
-    packages=($(pacman -Ssq "^$words[current]" 2>/dev/null))
+    if ! _retrieve_cache pacignore_packages; then
+      packages=($(pacman -Ssq 2>/dev/null))
+      _store_cache pacignore_packages packages
+    fi
     _describe 'packages' packages
   elif [[ $state == "subcmds" ]]; then
     _values "pacignore subcommands" \
@@ -20,4 +27,5 @@ _pacignore(){
 }
 
 _pacignore "$@"
-# vim: syntax=Shell
+
+# vim: ft=zsh

--- a/completion/pacignore/zsh
+++ b/completion/pacignore/zsh
@@ -1,7 +1,7 @@
 #compdef pacignore
 
 _pacignore_caching_policy () {
-  [[ "$1" -nt /var/log/pacman.log ]]
+  [[ "/var/log/pacman.log" -nt "$1" ]]
 }
 
 _pacignore(){

--- a/completion/pacignore/zsh
+++ b/completion/pacignore/zsh
@@ -1,15 +1,15 @@
 #compdef pacignore
 
 _pacignore_caching_policy () {
-  [[ "/var/log/pacman.log" -nt "$1" ]]
+  [[ '/var/log/pacman.log' -nt "$1" ]]
 }
 
 _set_pacignore_cache_policy () {
   local update_policy
-  zstyle -s ":completion:*:*:pacignore:*" cache-policy update_policy
+  zstyle -s ':completion:*:*:pacignore:*' cache-policy update_policy
 
   if [[ -z "$update_policy" ]]; then
-    zstyle ":completion:*:*:pacignore:*" cache-policy _pacignore_caching_policy
+    zstyle ':completion:*:*:pacignore:*' cache-policy _pacignore_caching_policy
   fi
 }
 
@@ -20,15 +20,15 @@ _pacignore () {
              '-c[pacman configuration file]:pacman config file:_files' \
              '-h[show help script]'
 
-  if [[ $state == "pkg" ]]; then
+  if [[ "$state" == 'pkg' ]]; then
     local -a packages
     if ! _retrieve_cache pacignore_packages; then
       packages=($(pacman -Ssq 2>/dev/null))
       _store_cache pacignore_packages packages
     fi
     _describe 'packages' packages
-  elif [[ $state == "subcmds" ]]; then
-    _values "pacignore subcommands" \
+  elif [[ "$state" == 'subcmds' ]]; then
+    _values 'pacignore subcommands' \
       'ls[list ignored package(s) in IgnorePkg]' \
       'check[check inclusion of package(s) in IgnorePkg]' \
       'add[add package(s) to IgnorePkg]' \


### PR DESCRIPTION
### Checklist

* Admin:
  - [x] No duplicate PRs
* Integration:
  - [x] Update shell completions
 
<!-- These are likely side tasks that would need to be completed before merging the pull request -->
<!-- If a task is not relevant to your pull request, simply remove its corresponding line -->

### Description

Following #211, I thought it would be a good idea to implement ZSH completion caching for `pacignore` (as we have it now for `downgrade`). This PR does the following:

1. 88fa098887f04514ede7d979f56f306cdcc36d19: Implements the ZSH completion caching feature for `pacignore`
2. f13c35772fcf3dee208394ffb314a51197fa7135: Potentially fixes a bug in the caching for both `downgrade` and `pacignore` by checking if `pacman.log` is newer than the cache, instead of vice versa that was done before

@pbrisbin could you help me check if the fix in point (2) makes sense? I could not find much documentation on the ZSH completion caching policy...

<!-- Describe your pull request and mention any issue(s) that it might be linked to -->