### PR TITLE
CI: allow manual workflow run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: main
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
### Checklist
not applicable

### Description

On https://github.com/archlinux-downgrade/downgrade/pull/217 test failure outputs differed on my local arch and on the ubuntu workflow so I wanted to be able to run the "CI" task myself. Github requires workflow_dispatch to be enabled on the main branch in order to manually run workflows so I added it to my fork.

Having my main and yours out of sync caused me to make a mess on rebasing https://github.com/archlinux-downgrade/downgrade/pull/217 so if you'd pull this change that's be a convenience for similar situations in the future