### PR TITLE
fix: use a variable name less likely to collide

### DIFF
--- a/src/downgrade
+++ b/src/downgrade
@@ -556,7 +556,7 @@ DOWNGRADE_TO_OLDEST=0
 DOWNGRADE_PREFER_CACHE=0
 
 # Main code execution
-if ((!LIB)); then
+if ((!DOWNGRADE_LIB)); then
   set -e
 
   locale="$(dirname "$0")"/../share/locale

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -1,5 +1,5 @@
 # Prevent actual execution of script
-export LIB=1
+export DOWNGRADE_LIB=1
 
 # Provide access to project root
 export SRCDIR=${TESTDIR/\/test*/}


### PR DESCRIPTION
We set `LIB=1` when running tests, so we can load the `downgrade` script
like a library and test individual functions.

It seems some systems might have an external `LIB=/usr/lib` variable
set. It's a syntax error to use a string variable with `((`, apparently,
causing downgrade to crash.

Renaming to `DOWNGRADE_LIB` also makes it consistent with our other
typical variables.

Fixes #252.
